### PR TITLE
feat(bmc_fw_update): compare version with filename

### DIFF
--- a/roles/bmc_fw_update/tasks/main.yml
+++ b/roles/bmc_fw_update/tasks/main.yml
@@ -82,7 +82,7 @@
   ansible.builtin.debug:
     msg: "{{ bmc_firmware_version }}"
 
-- name: Validate fw image changed from before
-  ansible.builtin.assert:
-    that:
-      - get_bmc_facts_before.redfish_facts.firmware.entries[0].Version != get_bmc_facts_after.redfish_facts.firmware.entries[0].Version
+- name: Validate fw image matches given filename
+  ansible.builtin.fail:
+    msg: "{{ bmc_fw_update_version_failure }}"
+  when: not bmc_fw_update_image.bmc is search(bmc_firmware_version | regex_search('[0-9-.]+'))

--- a/roles/bmc_fw_update/vars/main.yml
+++ b/roles/bmc_fw_update/vars/main.yml
@@ -5,6 +5,7 @@
 # vars file for bmc_fw_update
 
 bmc_fw_update_task_failure: "Task failed with status: %s"
+bmc_fw_update_version_failure: "Version returned from BMC doesn't match version in the file name"
 bmc_fw_update_image:
   url: https://content.mellanox.com/BlueField/BMC/23.10-1-oct-2023
   bmc: bf3-bmc-23.10-5_opn.fwpkg

--- a/roles/get_bmc_facts/tasks/main.yml
+++ b/roles/get_bmc_facts/tasks/main.yml
@@ -16,4 +16,4 @@
 
 - name: Extract BMC firmware version from inventory
   ansible.builtin.set_fact:
-    bmc_firmware_version: "{{ result.redfish_facts.firmware | community.general.json_query('entries[?Id==`BMC_Firmware`].Version') }}"
+    bmc_firmware_version: "{{ result.redfish_facts.firmware | community.general.json_query('entries[?Id==`BMC_Firmware`].Version') | first }}"


### PR DESCRIPTION
This is instead of comparing before and after version

Fixes #22

before the fix:
```
2024-02-27 00:19:40 TASK [bmc_fw_update : Print BMC Version] ***************************************
2024-02-27 00:19:40 task path: /home/boris/ansible-opi-dpu/roles/bmc_fw_update/tasks/main.yml:81
2024-02-27 00:19:40 ok: [10.10.10.1] => {
2024-02-27 00:19:40     "msg": [
2024-02-27 00:19:40         "BF-23.10-5"
2024-02-27 00:19:40     ]
2024-02-27 00:19:40 }
2024-02-27 00:19:40
2024-02-27 00:19:40 TASK [bmc_fw_update : Validate fw image changed from before] *******************
2024-02-27 00:19:40 task path: /home/boris/ansible-opi-dpu/roles/bmc_fw_update/tasks/main.yml:85
2024-02-27 00:19:40 fatal: [10.10.10.1]: FAILED! => {
2024-02-27 00:19:40     "msg": "The conditional check 'get_bmc_facts_before.redfish_facts.firmware.entries[0].Version != get_bmc_facts_after.redfish_facts.firmware.entries[0].Version' failed. The error was: error while evaluating conditional (get_bmc_facts_before.redfish_facts.firmware.entries[0].Version != get_bmc_facts_after.redfish_facts.firmware.entries[0].Version): 'dict object' has no attribute 'redfish_facts'. 'dict object' has no attribute 'redfish_facts'"
2024-02-27 00:19:40 }
2024-02-27 00:19:40
```

Signed-off-by: Boris Glimcher <Boris.Glimcher@emc.com>
