### PR TITLE
jgcastanos2-patch1-issue51

### DIFF
--- a/roles/bmc_fw_update/meta/main.yml
+++ b/roles/bmc_fw_update/meta/main.yml
@@ -50,3 +50,6 @@ galaxy_info:
 dependencies: []
   # List your role dependencies here, one per line. Be sure to remove the '[]' above,
   # if you add dependencies to this list.
+
+
+allow_duplicates: true

--- a/roles/bmc_fw_update/tasks/main.yml
+++ b/roles/bmc_fw_update/tasks/main.yml
@@ -4,14 +4,14 @@
 ---
 # tasks file for bmc_fw_update
 
-- name: Get Firmware Inventory
-  ansible.builtin.include_role:
-    name: get_bmc_facts
-  register: get_bmc_facts_before
+#- name: Get Firmware Inventory
+#  ansible.builtin.include_role:
+#    name: get_bmc_facts
+#  register: get_bmc_facts_before
 
-- name: Print BMC Version
-  ansible.builtin.debug:
-    msg: "{{ get_bmc_facts_bmc_firmware }}"
+#- name: Print BMC Version
+#  ansible.builtin.debug:
+#    var: vars.bmc_fw_version
 
 - name: Check if firmware image exists locally {{ bmc_fw_update_image_file }}
   ansible.builtin.stat:
@@ -27,7 +27,7 @@
   delegate_to: localhost
   when: not bmc_fw_update_local_file_check.stat.exists
 
-- name: Update BMC firmware of DPU
+- name: Update BMC firmware of DPU {{ bmc_fw_update_image_file }}
   community.general.redfish_command:
     category: Update
     command: MultipartHTTPPushUpdate
@@ -76,18 +76,22 @@
   when:
     - bmc_fw_update_reboot is true
 
+- name: Get the DPU a chance to restart
+  ansible.builtin.pause:
+    seconds: 120
+  when:
+    - bmc_fw_update_reboot is true
+
 - name: Get Firmware Inventory
   ansible.builtin.include_role:
     name: get_bmc_facts
   register: get_bmc_facts_after
 
-- name: Print BMC Version
-  ansible.builtin.debug:
-    msg: "{{ get_bmc_facts_bmc_firmware }}"
+- name: Store fw version we installed
+  ansible.builtin.set_fact:
+    got_fw_version: "{{ vars.bmc_fw_version[bmc_fw_check_field] }}"
 
-- name: Validate fw image matches given filename
+- name: Validate fw version matches goal
   ansible.builtin.fail:
-    msg: "{{ bmc_fw_update_version_failure }}"
-  when:
-    - bmc_fw_update_reboot is true
-    - not bmc_fw_update_image_file is search(get_bmc_facts_bmc_firmware | regex_search('[0-9-.]+'))
+    msg: "{{ got_fw_version }} does not match {{ bmc_fw_check_value }}"
+  when: got_fw_version != bmc_fw_check_value

--- a/roles/bmc_fw_update/vars/main.yml
+++ b/roles/bmc_fw_update/vars/main.yml
@@ -5,4 +5,3 @@
 # vars file for bmc_fw_update
 
 bmc_fw_update_task_failure: "Task failed with status: %s"
-bmc_fw_update_version_failure: "Version returned from BMC doesn't match version in the file name"

--- a/roles/get_bmc_facts/meta/main.yml
+++ b/roles/get_bmc_facts/meta/main.yml
@@ -50,3 +50,6 @@ galaxy_info:
 dependencies: []
   # List your role dependencies here, one per line. Be sure to remove the '[]' above,
   # if you add dependencies to this list.
+
+
+allow_duplicates: true

--- a/roles/get_bmc_facts/tasks/main.yml
+++ b/roles/get_bmc_facts/tasks/main.yml
@@ -16,5 +16,10 @@
 
 - name: Extract all FW versions to facts
   ansible.builtin.set_fact:
-    "{{ 'get_bmc_facts_' + item['Id'] | lower }}": "{{ item['Version'] }}"
+    bmc_fw_version: "{{ bmc_fw_version | default({}) | combine({ item['Id'] | lower : item['Version'] }) }}"
   loop: "{{ result.redfish_facts.firmware.entries }}"
+
+#- name: Print facts
+#  ansible.builtin.debug:
+#    var: vars.bmc_fw_version
+#  delegate_to: localhost

--- a/update_bf.yml
+++ b/update_bf.yml
@@ -1,0 +1,62 @@
+# exmaple run to update both the bmc fw and the cec in an NVIDIA BlueField
+# ansible-playbook -i ../inventory/bfbmcs.ini --extra-vars "dpu_bmc_username=${BMCUSER} dpu_bmc_password=${BMCPW} bmc_fw_filename=/home/sancho/bmcimages/bf3-bmc-23.10-5_opn.fwpkg bmc_cec_filename=/home/sancho/bmcimages/cec1736-ecfw-00.02.0152.0000-n02-rel-prod.fwpkg fw_version=BF-23.10-5 cec_version=00.02.0152.0000_n02" update_bf.yml
+#
+
+- hosts: bfbmcs
+  gather_facts: no
+  tasks:
+    - name: Install BMC fw
+      import_role:
+        name: bmc_fw_update
+      vars:
+        bmc_fw_update_image_file: "{{ bmc_fw_filename }}"
+        bmc_fw_update_reboot: false
+        bmc_fw_check_field: bmc_firmware
+        bmc_fw_check_value: "{{ fw_version }}"
+
+    - name: Install CEC and reboot
+      import_role:
+        name: bmc_fw_update
+      vars:
+        bmc_fw_update_image_file: "{{ bmc_cec_filename }}"
+        bmc_fw_update_reboot: true
+        bmc_fw_check_field: bluefield_fw_erot
+        bmc_fw_check_value: "{{ cec_version }}"
+
+
+# power cycle servers and wait until they come up
+
+
+- hosts: bfbmcs
+  gather_facts: no
+  tasks:
+    - name: Get fw version after reboot
+      import_role:
+        name: get_bmc_facts
+
+    - name: Print facts
+      ansible.builtin.debug:
+        var: vars.bmc_fw_version
+      delegate_to: localhost
+
+    - name: Store fw version we installed
+      ansible.builtin.set_fact:
+        got_fw_version: "{{ vars.bmc_fw_version['bmc_firmware'] }}"
+
+    - name: Store CEC version we installed
+      ansible.builtin.set_fact:
+        got_cec_version: "{{ vars.bmc_fw_version['bluefield_fw_erot'] }}"
+
+    - name: Validate fw image matches goal
+      ansible.builtin.fail:
+        msg: "FW version {{ got_fw_version }} does not match {{ fw_version }}"
+      when: got_fw_version != fw_version
+
+    - name: Validate cec image matches goal
+      ansible.builtin.fail:
+        msg: "CEC version {{ got_cec_version }} does not match {{ cec_version }}"
+      when: got_cec_version != cec_version
+
+   
+
+


### PR DESCRIPTION
First version of how to support both updates of the bmc and the cec in NVIDIA Bluefields.
- get_fw_facts now returns a dictionary of facts, rather than individual get_xxxx facts
- in bmc_fw_update, no need to get original fw (not used anywhere?), and passing the target fw as a string, rather than using filename. There's no real mapping between filenames and versions returned by the bmc
- allow call multiple times in meta/main.yml
- a sample update_fw.yml at the top shows how the bmc_fw_update can be called twice, and which vars to pass in each instance. There's a sample cmd line invocation at the top
- this file also shows how to check the update was successful after doing a power cycle of the server. Checks immediately after the update might be meaningless. 
- This update_fw.yml is Bluefield specific. It can be removed, but I am not sure how to document/explain the whole flow to the customers without it. It can also be adapted to fit customers needs. I see it more as part of documentation on how to use, rather than a strong role dependency.