### PR TITLE
Fixing Broken Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ More examples on this page [LIFECYCLE](https://github.com/opiproject/opi-prov-li
 
 This project welcomes contributions and suggestions.  We are happy to have the Community involved via submission of **Issues and Pull Requests** (with substantive content or even just fixes). We are hoping for the documents, test framework, etc. to become a community process with active engagement.  PRs can be reviewed by by any number of people, and a maintainer may accept.
 
-See [CONTRIBUTING](https://github.com/opiproject/opi/blob/main/CONTRIBUTING.md) and [GitHub Basic Process](https://github.com/opiproject/opi/blob/main/doc-github-rules.md) for more details.
+See [CONTRIBUTING](https://github.com/opiproject/opi/blob/main/CONTRIBUTING.md) and [GitHub Basic Process](https://github.com/opiproject/opi/blob/main/Policies/doc-github-rules.md) for more details.
 
 ## Getting started
 


### PR DESCRIPTION
Hello I was doing research for CNCF mentorship project. I realized link for "GitHub Basic Process" broken.