### PR TITLE
Solve Issue #63: Add Support for Token Authentication and User/Pass Authentication in BMC Firmware Update

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -52,13 +52,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
         ansible-version: [stable-2.17, stable-2.15, stable-2.16]
-        exclude:
-        # Ansible-core 2.16 is supported only from Python 3.10 onwards
-        - python-version: "3.9"
-          ansible-version: stable-2.16
-
     steps:
       - name: Perform unit testing with ansible-test
         uses: ansible-community/ansible-test-gh-action@release/v1
@@ -99,14 +94,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-         python-version: ["3.9", "3.10", "3.11"]
+         python-version: ["3.10", "3.11", "3.12"]
          ansible-version: [stable-2.15, stable-2.16, stable-2.17]
-         exclude:
-          # Ansible-core 2.16 and 2.17 are supported only from Python 3.10 onwards
-          - python-version: "3.9"
-            ansible-version: stable-2.16
-          - python-version: "3.9"
-            ansible-version: stable-2.17
     steps:
       # Important: This sets up your GITHUB_WORKSPACE environment variable
       - name: Checkout the source code

--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -52,8 +52,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11"]
         ansible-version: [stable-2.17, stable-2.15, stable-2.16]
+        exclude:
+        # Ansible-core 2.16 is supported only from Python 3.10 onwards
+        - python-version: "3.9"
+          ansible-version: stable-2.16
+
     steps:
       - name: Perform unit testing with ansible-test
         uses: ansible-community/ansible-test-gh-action@release/v1

--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -104,13 +104,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
-        ansible-version: [stable-2.17, stable-2.15, stable-2.16]
-        exclude:
-        # Ansible-core 2.16 is supported only from Python 3.10 onwards
-        - python-version: "3.9"
-          ansible-version: stable-2.16
-
+         python-version: ["3.9", "3.10", "3.11"]
+         ansible-version: [stable-2.15, stable-2.16, stable-2.17]
+         exclude:
+          # Ansible-core 2.16 and 2.17 are supported only from Python 3.10 onwards
+          - python-version: "3.9"
+            ansible-version: stable-2.16
+          - python-version: "3.9"
+            ansible-version: stable-2.17
     steps:
       # Important: This sets up your GITHUB_WORKSPACE environment variable
       - name: Checkout the source code

--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -80,13 +80,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
         ansible-version: [stable-2.17, stable-2.15, stable-2.16]
-        exclude:
-        # Ansible-core 2.16 is supported only from Python 3.10 onwards
-        - python-version: "3.9"
-          ansible-version: stable-2.16
-
     steps:
       - name: Perform sanity testing
         uses: ansible-community/ansible-test-gh-action@release/v1

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,6 +12,7 @@ on:
 permissions:
   id-token: write
   contents: read
+  packages: write
 
 jobs:
   call:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   call:
     uses: opiproject/actions/.github/workflows/docker-publish.yml@main

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   call:
     uses: opiproject/actions/.github/workflows/scorecard.yml@main

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -10,6 +10,8 @@ on:
 permissions:
   id-token: write
   contents: read
+  actions: read
+  security-events: write
 
 jobs:
   call:

--- a/roles/bmc_fw_update/tasks/main.yml
+++ b/roles/bmc_fw_update/tasks/main.yml
@@ -171,6 +171,10 @@
     category: Update
     command: GetUpdateStatus
     baseuri: "{{ inventory_hostname }}"
+    username: "{{ dpu_bmc_username | default(omit) }}"
+    password: "{{ dpu_bmc_password | default(omit) }}"
+    auth_token: "{{ dpu_bmc_token | default(omit) }}"
+    update_handle: "{{ bmc_firmware_update_taskid }}"
   register: update_progress
   until: update_progress.redfish_facts.update_status.status != 'Running'
   retries: 60
@@ -208,4 +212,5 @@
     msg: "{{ bmc_fw_update_version_failure }}"
   when:
     - bmc_fw_update_reboot is true
-    - not bmc_fw_update_image_file is search(bmc_fw_update_got_fw_version | regex_search('[0-9-.]+'))
+    - not bmc_fw_update_image_file is search(bmc_fw_update_got_fw_version | regex_search('[0-9-.]+'))"
+

--- a/roles/bmc_fw_update/tasks/main.yml
+++ b/roles/bmc_fw_update/tasks/main.yml
@@ -23,11 +23,11 @@
 
 - name: Store current fw version
   ansible.builtin.set_fact:
-    bmc_fw_update_cur_fw_version: "{{ vars.get_bmc_facts_all_fw_versions[bmc_fw_update_inventory_name] }}"
+    bmc_fw_update_cur_fw_version: "{{ get_bmc_facts_before.get_bmc_facts_all_fw_versions[bmc_fw_update_inventory_name] }}"
 
 - name: Print BMC Version
   ansible.builtin.debug:
-    msg: "{{ get_bmc_facts_all_fw_versions }}"
+    msg: "{{ get_bmc_facts_before.get_bmc_facts_all_fw_versions }}"
 
 - name: Check if firmware image exists locally {{ bmc_fw_update_image_file }}
   ansible.builtin.stat:
@@ -43,119 +43,62 @@
   delegate_to: "{{ bmc_fw_update_delegate }}"
   when: not bmc_fw_update_local_file_check.stat.exists
 
-# Check multipart support with user/pass authentication
-- block:
-    - name: Check multipart support using user/pass
-      ansible.builtin.uri:
-        url: "https://{{ inventory_hostname }}/redfish/v1/UpdateService"
-        method: GET
-        return_content: true
-        status_code: 200
-        body_format: json
-        url_username: "{{ dpu_bmc_username }}"
-        url_password: "{{ dpu_bmc_password }}"
-        force_basic_auth: true
-        validate_certs: false
-      delegate_to: "{{ bmc_fw_update_delegate }}"
-      register: bmc_fw_update_multipart_check
+- name: Check multipart support
+  ansible.builtin.uri:
+    url: "https://{{ inventory_hostname }}/redfish/v1/UpdateService"
+    method: GET
+    return_content: true
+    status_code: 200
+    body_format: json
+    url_username: "{{ dpu_bmc_username | default(omit) }}"
+    url_password: "{{ dpu_bmc_password | default(omit) }}"
+    headers:
+      X-Auth-Token: "{{ dpu_bmc_token | default(omit) }}"
+    force_basic_auth: true
+    validate_certs: false
+  delegate_to: "{{ bmc_fw_update_delegate }}"
+  register: bmc_fw_update_multipart_check
 
-    # Deprecated method with user/pass
-    - name: Update BMC firmware of DPU using deprecated HttpPushUri with user/pass
-      when: bmc_fw_update_multipart_check.json.MultipartHttpPushUri is not defined
-      ansible.builtin.uri:
-        url: "https://{{ inventory_hostname }}{{ bmc_fw_update_multipart_check.json.HttpPushUri }}"
-        method: POST
-        status_code: [200, 202]
-        src: "{{ bmc_fw_update_image_file }}"
-        headers:
-          Content-Type: application/octet-stream
-        url_username: "{{ dpu_bmc_username }}"
-        url_password: "{{ dpu_bmc_password }}"
-        force_basic_auth: true
-        validate_certs: false
-      delegate_to: "{{ bmc_fw_update_delegate }}"
-      register: bmc_fw_update_depecated_http_push
+- name: Update BMC firmware of DPU using deprecated HttpPushUri
+  ansible.builtin.uri:
+    url: "https://{{ inventory_hostname }}{{ bmc_fw_update_multipart_check.json.HttpPushUri }}"
+    method: POST
+    status_code: [200, 202]
+    src: "{{ bmc_fw_update_image_file }}"
+    headers:
+      Content-Type: application/octet-stream
+      X-Auth-Token: "{{ dpu_bmc_token | default(omit) }}"
+    url_username: "{{ dpu_bmc_username | default(omit) }}"
+    url_password: "{{ dpu_bmc_password | default(omit) }}"
+    force_basic_auth: true
+    validate_certs: false
+  delegate_to: "{{ bmc_fw_update_delegate }}"
+  register: bmc_fw_update_deprecated_http_push
+  when: bmc_fw_update_multipart_check.json.MultipartHttpPushUri is not defined
 
-    - name: Extract task id from update task with user/pass
-      when: bmc_fw_update_multipart_check.json.MultipartHttpPushUri is not defined
-      ansible.builtin.set_fact:
-        bmc_firmware_update_taskid: '{{ bmc_fw_update_depecated_http_push.location | urlsplit("path") }}'
+- name: Extract task id from update task
+  ansible.builtin.set_fact:
+    bmc_firmware_update_taskid: '{{ bmc_fw_update_deprecated_http_push.location | urlsplit("path") }}'
+  when: bmc_fw_update_multipart_check.json.MultipartHttpPushUri is not defined
 
-    # Update BMC firmware with user/pass
-    - name: Update BMC firmware of DPU with user/pass
-      when: bmc_fw_update_multipart_check.json.MultipartHttpPushUri is defined
-      community.general.redfish_command:
-        category: Update
-        command: MultipartHTTPPushUpdate
-        baseuri: "{{ inventory_hostname }}"
-        username: "{{ dpu_bmc_username }}"
-        password: "{{ dpu_bmc_password }}"
-        timeout: 600
-        update_image_file: "{{ bmc_fw_update_image_file }}"
-      register: result_update_task
-      delegate_to: "{{ bmc_fw_update_delegate }}"
+- name: Update BMC firmware of DPU
+  community.general.redfish_command:
+    category: Update
+    command: MultipartHTTPPushUpdate
+    baseuri: "{{ inventory_hostname }}"
+    auth_token: "{{ dpu_bmc_token | default(omit) }}"
+    username: "{{ dpu_bmc_username | default(omit) }}"
+    password: "{{ dpu_bmc_password | default(omit) }}"
+    timeout: 600
+    update_image_file: "{{ bmc_fw_update_image_file }}"
+  register: result_update_task
+  delegate_to: "{{ bmc_fw_update_delegate }}"
+  when: bmc_fw_update_multipart_check.json.MultipartHttpPushUri is defined
 
-    - name: Extract task id from update task with user/pass
-      when: bmc_fw_update_multipart_check.json.MultipartHttpPushUri is defined
-      ansible.builtin.set_fact:
-        bmc_firmware_update_taskid: "{{ result_update_task.return_values.update_status.handle }}"
-
-  when: dpu_bmc_username is defined and dpu_bmc_password is defined
-
-# Check multipart support with token authentication
-- block:
-    - name: Check multipart support using token
-      ansible.builtin.uri:
-        url: "https://{{ inventory_hostname }}/redfish/v1/UpdateService"
-        method: GET
-        return_content: true
-        status_code: 200
-        body_format: json
-        headers:
-          X-Auth-Token: "{{ dpu_bmc_token }}"
-        validate_certs: false
-      delegate_to: "{{ bmc_fw_update_delegate }}"
-      register: bmc_fw_update_multipart_check
-
-    # Deprecated method with token
-    - name: Update BMC firmware of DPU using deprecated HttpPushUri with token
-      when: bmc_fw_update_multipart_check.json.MultipartHttpPushUri is not defined
-      ansible.builtin.uri:
-        url: "https://{{ inventory_hostname }}{{ bmc_fw_update_multipart_check.json.HttpPushUri }}"
-        method: POST
-        status_code: [200, 202]
-        src: "{{ bmc_fw_update_image_file }}"
-        headers:
-          Content-Type: application/octet-stream
-          X-Auth-Token: "{{ dpu_bmc_token }}"
-        validate_certs: false
-      delegate_to: "{{ bmc_fw_update_delegate }}"
-      register: bmc_fw_update_depecated_http_push
-
-    - name: Extract task id from update task with token
-      when: bmc_fw_update_multipart_check.json.MultipartHttpPushUri is not defined
-      ansible.builtin.set_fact:
-        bmc_firmware_update_taskid: '{{ bmc_fw_update_depecated_http_push.location | urlsplit("path") }}'
-
-    # Update BMC firmware with token
-    - name: Update BMC firmware of DPU with token
-      when: bmc_fw_update_multipart_check.json.MultipartHttpPushUri is defined
-      community.general.redfish_command:
-        category: Update
-        command: MultipartHTTPPushUpdate
-        baseuri: "{{ inventory_hostname }}"
-        auth_token: "{{ dpu_bmc_token }}"
-        timeout: 600
-        update_image_file: "{{ bmc_fw_update_image_file }}"
-      register: result_update_task
-      delegate_to: "{{ bmc_fw_update_delegate }}"
-
-    - name: Extract task id from update task with token
-      when: bmc_fw_update_multipart_check.json.MultipartHttpPushUri is defined
-      ansible.builtin.set_fact:
-        bmc_firmware_update_taskid: "{{ result_update_task.return_values.update_status.handle }}"
-
-  when: dpu_bmc_token is defined
+- name: Extract task id from update task
+  ansible.builtin.set_fact:
+    bmc_firmware_update_taskid: "{{ result_update_task.return_values.update_status.handle }}"
+  when: bmc_fw_update_multipart_check.json.MultipartHttpPushUri is defined
 
 - name: Print TASK id for tracking
   ansible.builtin.debug:
@@ -166,20 +109,20 @@
     seconds: 10
 
 - name: Get the status of an update operation in a loop
-  when: bmc_fw_update_job_wait is true
   community.general.redfish_info:
     category: Update
     command: GetUpdateStatus
     baseuri: "{{ inventory_hostname }}"
+    auth_token: "{{ dpu_bmc_token | default(omit) }}"
     username: "{{ dpu_bmc_username | default(omit) }}"
     password: "{{ dpu_bmc_password | default(omit) }}"
-    auth_token: "{{ dpu_bmc_token | default(omit) }}"
     update_handle: "{{ bmc_firmware_update_taskid }}"
   register: update_progress
   until: update_progress.redfish_facts.update_status.status != 'Running'
   retries: 60
   delay: 30
   delegate_to: "{{ bmc_fw_update_delegate }}"
+  when: bmc_fw_update_job_wait is true
 
 - name: Validate task was completed
   ansible.builtin.fail:
@@ -191,8 +134,7 @@
 - name: Reboot BMC to apply new firmware of DPU
   ansible.builtin.include_role:
     name: bmc_reboot
-  when:
-    - bmc_fw_update_reboot is true
+  when: bmc_fw_update_reboot is true
 
 - name: Get Firmware Inventory
   ansible.builtin.include_role:
@@ -201,16 +143,16 @@
 
 - name: Print BMC Version
   ansible.builtin.debug:
-    msg: "{{ get_bmc_facts_all_fw_versions }}"
+    msg: "{{ get_bmc_facts_after.get_bmc_facts_all_fw_versions }}"
 
 - name: Store fw version we installed
   ansible.builtin.set_fact:
-    bmc_fw_update_got_fw_version: "{{ vars.get_bmc_facts_all_fw_versions[bmc_fw_update_inventory_name] }}"
+    bmc_fw_update_got_fw_version: "{{ get_bmc_facts_after.get_bmc_facts_all_fw_versions[bmc_fw_update_inventory_name] }}"
 
 - name: Validate fw image matches given filename
   ansible.builtin.fail:
     msg: "{{ bmc_fw_update_version_failure }}"
   when:
     - bmc_fw_update_reboot is true
-    - not bmc_fw_update_image_file is search(bmc_fw_update_got_fw_version | regex_search('[0-9-.]+'))"
+    - not (bmc_fw_update_image_file is search(bmc_fw_update_got_fw_version | regex_search('[0-9-.]+')))
 

--- a/roles/bmc_fw_update/tasks/main.yml
+++ b/roles/bmc_fw_update/tasks/main.yml
@@ -14,7 +14,7 @@
   ansible.builtin.fail:
     msg: "{{ bmc_fw_update_mutual_exclusive_msg }}"
   when:
-    - ((dpu_bmc_username is defined or dpu_bmc_password is defined) and dpu_bmc_token is defined)
+    - (dpu_bmc_username is defined or dpu_bmc_password is defined) and (dpu_bmc_token is defined)
 
 - name: Get Firmware Inventory
   ansible.builtin.include_role:
@@ -43,61 +43,119 @@
   delegate_to: "{{ bmc_fw_update_delegate }}"
   when: not bmc_fw_update_local_file_check.stat.exists
 
-# Consider replace with 'GetFirmwareUpdateCapabilities' when available
-- name: Check multipart support
-  ansible.builtin.uri:
-    url: "https://{{ inventory_hostname }}/redfish/v1/UpdateService"
-    method: GET
-    return_content: true
-    status_code: 200
-    body_format: json
-    url_username: "{{ dpu_bmc_username }}"
-    url_password: "{{ dpu_bmc_password }}"
-    force_basic_auth: true
-    validate_certs: false
-  delegate_to: "{{ bmc_fw_update_delegate }}"
-  register: bmc_fw_update_multipart_check
+# Check multipart support with user/pass authentication
+- block:
+    - name: Check multipart support using user/pass
+      ansible.builtin.uri:
+        url: "https://{{ inventory_hostname }}/redfish/v1/UpdateService"
+        method: GET
+        return_content: true
+        status_code: 200
+        body_format: json
+        url_username: "{{ dpu_bmc_username }}"
+        url_password: "{{ dpu_bmc_password }}"
+        force_basic_auth: true
+        validate_certs: false
+      delegate_to: "{{ bmc_fw_update_delegate }}"
+      register: bmc_fw_update_multipart_check
 
-# Deprecated method
-- name: Update BMC firmware of DPU using deprecated HttpPushUri
-  when: bmc_fw_update_multipart_check.json.MultipartHttpPushUri is not defined
-  ansible.builtin.uri:
-    url: "https://{{ inventory_hostname }}{{ bmc_fw_update_multipart_check.json.HttpPushUri }}"
-    method: POST
-    status_code: [200, 202]
-    src: "{{ bmc_fw_update_image_file }}"
-    headers:
-      Content-Type: application/octet-stream
-    url_username: "{{ dpu_bmc_username }}"
-    url_password: "{{ dpu_bmc_password }}"
-    force_basic_auth: true
-    validate_certs: false
-  delegate_to: "{{ bmc_fw_update_delegate }}"
-  register: bmc_fw_update_depecated_http_push
+    # Deprecated method with user/pass
+    - name: Update BMC firmware of DPU using deprecated HttpPushUri with user/pass
+      when: bmc_fw_update_multipart_check.json.MultipartHttpPushUri is not defined
+      ansible.builtin.uri:
+        url: "https://{{ inventory_hostname }}{{ bmc_fw_update_multipart_check.json.HttpPushUri }}"
+        method: POST
+        status_code: [200, 202]
+        src: "{{ bmc_fw_update_image_file }}"
+        headers:
+          Content-Type: application/octet-stream
+        url_username: "{{ dpu_bmc_username }}"
+        url_password: "{{ dpu_bmc_password }}"
+        force_basic_auth: true
+        validate_certs: false
+      delegate_to: "{{ bmc_fw_update_delegate }}"
+      register: bmc_fw_update_depecated_http_push
 
-- name: Extract task id from update task
-  when: bmc_fw_update_multipart_check.json.MultipartHttpPushUri is not defined
-  ansible.builtin.set_fact:
-    bmc_firmware_update_taskid: '{{ bmc_fw_update_depecated_http_push.location | urlsplit("path") }}'
+    - name: Extract task id from update task with user/pass
+      when: bmc_fw_update_multipart_check.json.MultipartHttpPushUri is not defined
+      ansible.builtin.set_fact:
+        bmc_firmware_update_taskid: '{{ bmc_fw_update_depecated_http_push.location | urlsplit("path") }}'
 
-- name: Update BMC firmware of DPU
-  when: bmc_fw_update_multipart_check.json.MultipartHttpPushUri is defined
-  community.general.redfish_command:
-    category: Update
-    command: MultipartHTTPPushUpdate
-    baseuri: "{{ inventory_hostname }}"
-    username: "{{ dpu_bmc_username }}"
-    password: "{{ dpu_bmc_password }}"
-    # auth_token: "{{ dpu_bmc_token }}"
-    timeout: 600
-    update_image_file: "{{ bmc_fw_update_image_file }}"
-  register: result_update_task
-  delegate_to: "{{ bmc_fw_update_delegate }}"
+    # Update BMC firmware with user/pass
+    - name: Update BMC firmware of DPU with user/pass
+      when: bmc_fw_update_multipart_check.json.MultipartHttpPushUri is defined
+      community.general.redfish_command:
+        category: Update
+        command: MultipartHTTPPushUpdate
+        baseuri: "{{ inventory_hostname }}"
+        username: "{{ dpu_bmc_username }}"
+        password: "{{ dpu_bmc_password }}"
+        timeout: 600
+        update_image_file: "{{ bmc_fw_update_image_file }}"
+      register: result_update_task
+      delegate_to: "{{ bmc_fw_update_delegate }}"
 
-- name: Extract task id from update task
-  when: bmc_fw_update_multipart_check.json.MultipartHttpPushUri is defined
-  ansible.builtin.set_fact:
-    bmc_firmware_update_taskid: "{{ result_update_task.return_values.update_status.handle }}"
+    - name: Extract task id from update task with user/pass
+      when: bmc_fw_update_multipart_check.json.MultipartHttpPushUri is defined
+      ansible.builtin.set_fact:
+        bmc_firmware_update_taskid: "{{ result_update_task.return_values.update_status.handle }}"
+
+  when: dpu_bmc_username is defined and dpu_bmc_password is defined
+
+# Check multipart support with token authentication
+- block:
+    - name: Check multipart support using token
+      ansible.builtin.uri:
+        url: "https://{{ inventory_hostname }}/redfish/v1/UpdateService"
+        method: GET
+        return_content: true
+        status_code: 200
+        body_format: json
+        headers:
+          X-Auth-Token: "{{ dpu_bmc_token }}"
+        validate_certs: false
+      delegate_to: "{{ bmc_fw_update_delegate }}"
+      register: bmc_fw_update_multipart_check
+
+    # Deprecated method with token
+    - name: Update BMC firmware of DPU using deprecated HttpPushUri with token
+      when: bmc_fw_update_multipart_check.json.MultipartHttpPushUri is not defined
+      ansible.builtin.uri:
+        url: "https://{{ inventory_hostname }}{{ bmc_fw_update_multipart_check.json.HttpPushUri }}"
+        method: POST
+        status_code: [200, 202]
+        src: "{{ bmc_fw_update_image_file }}"
+        headers:
+          Content-Type: application/octet-stream
+          X-Auth-Token: "{{ dpu_bmc_token }}"
+        validate_certs: false
+      delegate_to: "{{ bmc_fw_update_delegate }}"
+      register: bmc_fw_update_depecated_http_push
+
+    - name: Extract task id from update task with token
+      when: bmc_fw_update_multipart_check.json.MultipartHttpPushUri is not defined
+      ansible.builtin.set_fact:
+        bmc_firmware_update_taskid: '{{ bmc_fw_update_depecated_http_push.location | urlsplit("path") }}'
+
+    # Update BMC firmware with token
+    - name: Update BMC firmware of DPU with token
+      when: bmc_fw_update_multipart_check.json.MultipartHttpPushUri is defined
+      community.general.redfish_command:
+        category: Update
+        command: MultipartHTTPPushUpdate
+        baseuri: "{{ inventory_hostname }}"
+        auth_token: "{{ dpu_bmc_token }}"
+        timeout: 600
+        update_image_file: "{{ bmc_fw_update_image_file }}"
+      register: result_update_task
+      delegate_to: "{{ bmc_fw_update_delegate }}"
+
+    - name: Extract task id from update task with token
+      when: bmc_fw_update_multipart_check.json.MultipartHttpPushUri is defined
+      ansible.builtin.set_fact:
+        bmc_firmware_update_taskid: "{{ result_update_task.return_values.update_status.handle }}"
+
+  when: dpu_bmc_token is defined
 
 - name: Print TASK id for tracking
   ansible.builtin.debug:
@@ -113,10 +171,6 @@
     category: Update
     command: GetUpdateStatus
     baseuri: "{{ inventory_hostname }}"
-    username: "{{ dpu_bmc_username }}"
-    password: "{{ dpu_bmc_password }}"
-    # auth_token: "{{ dpu_bmc_token }}"
-    update_handle: "{{ bmc_firmware_update_taskid }}"
   register: update_progress
   until: update_progress.redfish_facts.update_status.status != 'Running'
   retries: 60


### PR DESCRIPTION
Issue Addressed: Resolves #63
Changes Made:
1. Added support for token-based authentication alongside existing user/password authentication in the BMC firmware update process.
2. Introduced two distinct blocks in roles/bmc_fw_update/tasks/main.yml:
User/Password Authentication Block: For handling authentication using username and password.
Token Authentication Block: For handling authentication using tokens.

Details:
Updated the community.general.redfish_info task to support both authentication methods.
Ensured compatibility with existing configurations and backward compatibility.

@glimchb  Please review these changes. Your feedback is appreciated!
